### PR TITLE
:Ftype commands, only search globbed portion, more globs

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,0 +1,4 @@
+{
+  "*.vim": { "type": "vim" },
+  "*.md": { "type": "doc" }
+}

--- a/plugin/fuzzy_projectionist.vim
+++ b/plugin/fuzzy_projectionist.vim
@@ -1,9 +1,100 @@
 if exists('g:loaded_fuzzy_projectionist') || &cp
-  finish
+  " finish
 endif
 let g:loaded_fuzzy_projectionist = 1
 let b:projections = {}
 let g:fuzzy_projectionist_finder_command = 'FZF'
+
+" " for if you're ever adding windows support {{{
+" function! fuzzy_projectionist#slash(...) abort
+"   let s = exists('+shellslash') && !&shellslash ? '\' : '/'
+"   return a:0 ? tr(a:1, '/', s) : s
+" endfunction
+" " normalizes slashes
+" function! s:slash(str) abort
+"   return tr(a:str, fuzzy_projectionist#slash(), '/')
+" endfunction " }}}
+
+function! s:count_stars(proj_glob) abort
+  let nmatches = len(split(a:proj_glob, '\*', 1)) - 1
+  return nmatches
+endfunction
+
+function! s:glob_to_regex(g) abort
+  let glob = a:g
+  let glob = substitute(glob, '\.', '\\.', 'g')
+  let glob = substitute(glob, "'", "\\'", "g")
+  if (s:count_stars(glob) > 1)
+    " cater for ..../k*k where k = ([^\/\*])?
+    let glob = substitute(glob, '\([^/\*]*\)\*\([^/\*]*\)$', "\\1________FZP_FILENAME________\\2", "g")
+    " any remaining **/ glob is the regex .*
+    " (allow xxx/**/*.txt to match xxx/thing.txt)
+    let glob = substitute(glob, '/\*\**/', "/*", "g")
+    " any remaining **, ***, ****** sequence is the regex .*
+    let glob = substitute(glob, '\*\**', ".*", "g")
+    " filenames are just non-slash chars
+    let glob = substitute(glob, '________FZP_FILENAME________', "[^/]*", "g")
+  else
+    let glob = substitute(glob, '\*', ".*", "g")
+  endif
+  return glob
+endfunction
+
+" try to use projectionist itself? {{{
+" function! s:call_projectionist_glob(g) abort
+"   let glob = a:g
+"   if (s:count_stars(glob) == 1)
+"     let glob = substitute(glob, '\*', '**/*', 'g')
+"   endif
+"   " this is what projectionist does?
+"   let glob = substitute(glob, '[^\/]*\ze\*\*[\/]\*', '', 'g')
+"   let matches = projectionist#glob(glob, 1)
+"   return matches
+"   " return map(matches, 'fnameescape(v:val)')
+" endfunction "}}}
+
+function! s:maxdir(g) abort
+  let upto_star = matchstr(a:g, '.*\ze\*')
+  return matchstr(upto_star, '.*\ze/')
+endfunction
+
+function! s:after_glob(g) abort
+  return matchstr(a:g, '[^\*]*$')
+endfunction
+
+function! s:glob_portion(g) abort
+  let maxdir = len(s:maxdir(a:g))
+  return a:g[maxdir+1:]
+endfunction
+
+function! s:fzf_source(g) abort
+  let cmd = ''
+  if executable('fd')
+    let glob = s:glob_portion(a:g)
+    let cmd = 'fd --type f --full-path '. "'" . s:glob_to_regex(glob) . "'"
+  else
+    let glob = s:glob_portion(a:g)
+    " strip leading ./ as well to match fd and plain vim-projectionist
+    " POSIX compatible
+    let cmd = 'find . -regex ' . "'".s:glob_to_regex(glob)."'". ' | sed "s|^\./||"'
+  endif
+  let after = s:after_glob(a:g)
+  let cmd = cmd . '| sed "s|'.after.'\$||"'
+  echom cmd
+  return cmd
+endfunction
+
+func! s:sink(lines, dir, after) abort
+  echom 'fuzzy proj sink '.len(a:lines)
+  if len(a:lines) < 2 | return | endif
+  let cmd = get({'ctrl-x': 'split',
+               \ 'ctrl-v': 'vertical split',
+               \ 'ctrl-t': 'tabe'}, a:lines[0], 'e')
+  let list = a:lines[1:]
+
+  let first = a:dir . list[0] . a:after
+  execute cmd escape(first, ' %#\')
+endfunc
 
 function! fuzzy_projectionist#projection_for_type(type) abort
   if exists('b:projections ') && b:projections != {}
@@ -11,8 +102,15 @@ function! fuzzy_projectionist#projection_for_type(type) abort
     if has_key(b:projections, cwd)
       let projections_for_cwd = b:projections[cwd]
       if has_key(projections_for_cwd, a:type)
-        let dir_to_search = projections_for_cwd[a:type]
-        exe g:fuzzy_projectionist_finder_command . ' ' . dir_to_search
+        let glob   = projections_for_cwd[a:type]
+        let source = s:fzf_source(glob)
+        let dir    = cwd."/".s:maxdir(glob)."/"
+        let after  = s:after_glob(glob)
+        let Func   = { lines -> s:sink(lines, dir, after) }
+        let fzf_options = '--expect=ctrl-t,ctrl-v,ctrl-x'
+        let opts   = fzf#wrap(a:type, { 'source': source, 'dir': dir, 'sink*': Func, 'options': fzf_options }, 0)
+
+        call fzf#run(opts)
       else
         echo 'No ' . a:type . ' projections for this project'
       endif
@@ -66,8 +164,17 @@ function! s:extract_projections(raw_projections) abort
      if !has_key(b:projections, working_dir)
        let b:projections[working_dir] = {}
      endif
-     let b:projections[working_dir][type] = fnamemodify(projection_path, ":p:h")
+     let b:projections[working_dir][type] = projection_path
+     " fnamemodify(projection_path, ":p:h")
    endfor
+  endfor
+endfunction
+
+function! fuzzy_projectionist#define_command(command, patterns) abort
+  for [prefix, excmd] in items(s:prefixes)
+    execute 'command! -buffer -bar -bang -nargs=* -complete=customlist,s:projection_complete'
+          \ prefix . substitute(a:command, '\A', '', 'g')
+          \ ':execute s:open_projection("<mods>", "'.excmd.'<bang>",'.string(a:patterns).',<f-args>)'
   endfor
 endfunction
 

--- a/plugin/fuzzy_projectionist.vim
+++ b/plugin/fuzzy_projectionist.vim
@@ -3,7 +3,6 @@ if exists('g:loaded_fuzzy_projectionist') || &cp || !has('lambda')
 endif
 let g:loaded_fuzzy_projectionist = 1
 let b:projections = {}
-let g:fuzzy_projectionist_finder_command = 'FZF'
 
 " " for if you're ever adding windows support {{{
 " function! fuzzy_projectionist#slash(...) abort
@@ -106,7 +105,7 @@ function! fuzzy_projectionist#projection_for_type(type) abort
         let dir    = cwd."/".s:maxdir(glob)."/"
         let after  = s:after_glob(glob)
         let Func   = { lines -> s:sink(lines, dir, after) }
-        let fzf_options = '--expect=ctrl-t,ctrl-v,ctrl-x'
+        let fzf_options = '--expect=ctrl-t,ctrl-v,ctrl-x --prompt "projectionist:'.a:type.'> "'
         let opts   = fzf#wrap(a:type, { 'source': source, 'dir': dir, 'sink*': Func, 'options': fzf_options }, 0)
         call fzf#run(opts)
       else
@@ -154,8 +153,6 @@ function! fuzzy_projectionist#available_projections() abort
   endif
   return {}
 endfunction
-
-let s:prefixes = ['E', 'edit']
 
 function! s:extract_projections(raw_projections) abort
   let b:projections = {}

--- a/plugin/fuzzy_projectionist.vim
+++ b/plugin/fuzzy_projectionist.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_fuzzy_projectionist') || &cp
+if exists('g:loaded_fuzzy_projectionist') || &cp || !has('lambda')
   finish
 endif
 let g:loaded_fuzzy_projectionist = 1

--- a/plugin/fuzzy_projectionist.vim
+++ b/plugin/fuzzy_projectionist.vim
@@ -37,6 +37,7 @@ function! s:glob_to_regex(g) abort
   else
     let glob = substitute(glob, '\*', ".*", "g")
   endif
+  let glob = glob . "$"
   return glob
 endfunction
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ Project navigation and fuzzy finders combined!
 
 Use projections and FZF together to navigate projects with ease.
 
+Supports Vim >= `7.4.2044` and Neovim (requires `echo has('lambda')`).
+
 ## Features
 
 Integrates with [vim-projectionist][] and [fzf][] to allow you to narrow the

--- a/readme.md
+++ b/readme.md
@@ -21,29 +21,36 @@ With this minimal configuration for a Rails project:
 
 ```json
 {
-  "app/models/*rb": {
+  "app/models/*.rb": {
     "type": "model"
   },
-  "app/controllers/*rb": {
+  "app/controllers/*.rb": {
     "type": "controller"
   },
-  "app/views/*rb": {
+  "app/views/*.rb": {
     "type": "view"
   }
 }
 ```
 
-You can now use FZF when projecting around the project with the functions:
+You can now use FZF when projecting around the project with the commands:
+
+- `:Fmodel`
+- `:Fcontroller`
+- `:Fview`
+
+Hit enter to dive into FZF for that type.
+
+When you're in FZF, use `enter` to open the file in the current buffer, `ctrl-x` to open in a new
+split, `ctrl-v` for a vertical split or `ctrl-t` for a new tab.
+
+There are also the following functions defined for further use:
 
 - `fuzzy_projectionist#projection_for_type(type)`
   - fuzzy search for projections for the given type in the cws
   - eg `fuzzy_projectionist#projection_for_type('model')`
 - `fuzzy_projectionist#choose_projection()`
   - choose which type of file to project
-
-
-Use enter to open the file in the current buffer, `ctrl-x` to open in a new
-split, `ctrl-v` for a vertical split or `ctrl-t` for a new tab.
 
 [vim-projectionist]: https://github.com/tpope/vim-projectionist
 [fzf]:               https://github.com/junegunn/fzf


### PR DESCRIPTION
**Before PR**

- didn't support patterns like `src/app/*/module.ts`
- showed filepath + extension in fzf, unlike the original vim-projectionist
- long fzf prompt
- only defined functions, you have to make your own mappings :(

![old](https://user-images.githubusercontent.com/378760/46963379-3504c180-d0f1-11e8-890f-c51d0d8b85f4.png)


**After PR**
- includes `Ftype` for every type, so you get command-line completion of `:Ft -> :Ftype` for free
- still supports `ctrl-v` etc
- supports more of the patterns projectionist does, and a LOT faster than the original projectionist's vim-based globbing
    - (uses `fd -type f` with `find .` fallback, and regexes transformed from globs)
- shows only glob part in fzf for higher match accuracy and matching original plugin
- nicer prompt
- supports more recent Vims only

![new](https://user-images.githubusercontent.com/378760/46963218-ca538600-d0f0-11e8-93a6-141c308573a8.png)
